### PR TITLE
Add flag description start column configuration

### DIFF
--- a/example/CMakeLists.txt
+++ b/example/CMakeLists.txt
@@ -17,3 +17,6 @@ target_link_libraries (simple)
 
 add_executable (optional optional.cc)
 target_link_libraries (optional)
+
+add_executable (long long.cc)
+target_link_libraries (long)

--- a/example/long.cc
+++ b/example/long.cc
@@ -1,0 +1,21 @@
+#include <sargs.h>
+
+using namespace std;
+
+#include <sargs.h>
+
+int main(int argc, char* argv[]) {
+  SARGS_REQUIRED_FLAG_VALUE("--foo", "-f", "The description of foo");
+  SARGS_OPTIONAL_FLAG("--thisisaverylongflagthatwillchangewherethedescriptionstarts", "", "The bar flag to help");
+
+  // This will move the start column further to the right. Rather than trying to figure it out, just let the user
+  // set it.
+  SARGS_SET_DESC_START_COLUMN(70);
+  SARGS_INITIALIZE(argc, argv);
+
+  //
+  // Run program code
+  //
+
+  return 0;
+}

--- a/src/sargs.h
+++ b/src/sargs.h
@@ -407,6 +407,10 @@ class Args {
     _usage_enabled = false;
   }
 
+  void SetDescStartColumn(const unsigned column) {
+    _desc_start = column;
+  }
+
   std::string GetPreamble() const {
     return _preamble;
   }
@@ -464,6 +468,7 @@ class Args {
   bool _exit_enabled = true;
   bool _exceptions_enabled = true;
   bool _usage_enabled = true;
+  unsigned _desc_start = 30;
 
   bool CheckIfNonValueFlag(const std::string& flag) const {
     for (auto iter : _required) {
@@ -692,7 +697,7 @@ class Args {
           flag_ids << "=value";
       }
 
-      output << std::left << std::setw(30) << flag_ids.str();
+      output << std::left << std::setw(_desc_start) << flag_ids.str();
       output << std::left << this->FormatDescription(arguments[i].description);
       output << '\n';
     }
@@ -892,5 +897,9 @@ class Args {
 // Disables printing usage if an error is encountered during initialization
 #define SARGS_DISABLE_USAGE() \
   sargs::Args::Default().DisableUsage()
+
+// Sets the start column of each description in the usage generator
+#define SARGS_SET_DESC_START_COLUMN(column) \
+  sargs::Args::Default().SetDescStartColumn(column)
 
 }  // namespace sargs


### PR DESCRIPTION
This will allow the user to set where their descriptions begin.
Addresses issue #26.